### PR TITLE
Truncate prompts that are too long in s3.

### DIFF
--- a/dalle_bot/dalle.py
+++ b/dalle_bot/dalle.py
@@ -120,7 +120,7 @@ def upload_to_s3(prompt, url):
 
     rand_tag = ''.join(random.choices(string.ascii_uppercase +
                              string.digits, k=10))
-    final_file = f'{prompt.replace(" ", "_")}_{rand_tag}.jpeg'
+    final_file = f'{prompt[:512].replace(" ", "_")}_{rand_tag}.jpeg'
     encoded = urllib.parse.quote(final_file)
     print(f'Final file {final_file}, Encoded url: {encoded}')
     s3_client.upload_file(comp_local_file, 'dallepics', f'dalle/{final_file}')


### PR DESCRIPTION
According to [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html) object keys may be up to 1024 bytes. Truncate filenames to 512 bytes (arbitrarily chosen) here.